### PR TITLE
Use Ed25519 alg instead of EdDSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ composer require olipayne/guzzle-web-bot-auth-middleware
 
 ## Prerequisites & Setup (Ed25519)
 
-To use this middleware, you need an Ed25519 private key, its corresponding public key (in JWK format hosted publicly), and a `keyid` (JWK Thumbprint of the public key). The middleware uses `alg: "eddsa"` in the `Signature-Input` header.
+To use this middleware, you need an Ed25519 private key, its corresponding public key (in JWK format hosted publicly), and a `keyid` (JWK Thumbprint of the public key). The middleware uses `alg: "ed25519"` in the `Signature-Input` header.
 
 ### Easiest Setup: All-in-One Ed25519 Key Generation Script
 
@@ -65,7 +65,7 @@ This package includes a utility script to generate everything you need for Ed255
         "crv": "Ed25519",
         "x": "...base64url_encoded_public_key...",
         "kid": "YOUR_GENERATED_ED25519_KEY_ID",
-        "alg": "EdDSA",
+        "alg": "ed25519",
         "use": "sig"
     }
     ...
@@ -85,7 +85,7 @@ This package includes a utility script to generate everything you need for Ed255
           "crv": "Ed25519",
           "x": "...base64url_encoded_public_key...",
           "kid": "YOUR_GENERATED_ED25519_KEY_ID",
-          "alg": "EdDSA",
+          "alg": "ed25519",
           "use": "sig"
         }
       ]
@@ -169,12 +169,12 @@ try {
 ### Covered Components & Algorithm
 
 *   **Covered Components:** `("@authority" "signature-agent")`
-*   **Signature Algorithm (in `Signature-Input`):** `alg="eddsa"` (implies Ed25519 with this library)
-*   **JWK Algorithm (`alg` in JWK):** `EdDSA`
+*   **Signature Algorithm (in `Signature-Input`):** `alg="ed25519"` (implies Ed25519 with this library)
+*   **JWK Algorithm (`alg` in JWK):** `Ed25519`
 
 ## How it Works
 
-The middleware uses `sodium_crypto_sign_detached` for Ed25519 signatures. The `Signature-Input` header includes an `alg="eddsa"` parameter. The JWK for the public key uses `kty: "OKP"` (Octet Key Pair) and `crv: "Ed25519"`.
+The middleware uses `sodium_crypto_sign_detached` for Ed25519 signatures. The `Signature-Input` header includes an `alg="ed25519"` parameter. The JWK for the public key uses `kty: "OKP"` (Octet Key Pair) and `crv: "Ed25519"`.
 
 ## Contributing
 

--- a/bin/generate-jwk.php
+++ b/bin/generate-jwk.php
@@ -73,7 +73,7 @@ $jwk = [
     'crv' => 'Ed25519',
     'x'   => $x_b64url,
     'kid' => $kid,
-    'alg' => 'EdDSA',
+    'alg' => 'Ed25519',
     'use' => 'sig'
 ];
 

--- a/bin/generate-keys.php
+++ b/bin/generate-keys.php
@@ -74,7 +74,7 @@ $jwk = [
     'crv' => 'Ed25519',
     'x'   => $x_b64url,
     'kid' => $kid,
-    'alg' => 'EdDSA', // Algorithm for use with this key (note: Signature-Input uses 'eddsa', JWK often 'EdDSA')
+    'alg' => 'Ed25519', // Algorithm for use with this key (note: Signature-Input uses 'ed25519', JWK often 'Ed25519')
     'use' => 'sig'
 ];
 

--- a/src/WebBotAuthMiddleware.php
+++ b/src/WebBotAuthMiddleware.php
@@ -13,7 +13,7 @@ class WebBotAuthMiddleware
     private string $signatureAgent;
     private string $tag;
     private int $expiresInSeconds;
-    private string $alg = 'eddsa'; // Algorithm identifier for EdDSA with Ed25519
+    private string $alg = 'ed25519'; // Algorithm identifier for Ed25519 with Ed25519
 
     public function __construct(
         string $base64Ed25519PrivateKeyOrPath,

--- a/tests/WebBotAuthIntegrationTest.php
+++ b/tests/WebBotAuthIntegrationTest.php
@@ -88,7 +88,7 @@ class WebBotAuthIntegrationTest extends TestCase
             $this->assertStringContainsString('created=', $receivedHeaders['signature-input']);
             $this->assertStringContainsString('expires=', $receivedHeaders['signature-input']);
             $this->assertStringContainsString('keyid="' . $kid . '"', $receivedHeaders['signature-input']);
-            $this->assertStringContainsString('alg="eddsa"', $receivedHeaders['signature-input']);
+            $this->assertStringContainsString('alg="ed25519"', $receivedHeaders['signature-input']);
             $this->assertStringContainsString('tag="web-bot-auth"', $receivedHeaders['signature-input']);
             
             $this->assertArrayHasKey('signature', $receivedHeaders);

--- a/tests/WebBotAuthMiddlewareTest.php
+++ b/tests/WebBotAuthMiddlewareTest.php
@@ -107,7 +107,7 @@ class WebBotAuthMiddlewareTest extends TestCase
             $signatureInput = $req->getHeaderLine('Signature-Input');
             $this->assertStringStartsWith('sig=(', $signatureInput);
             $this->assertStringContainsString('keyid="' . $this->validKeyId . '"', $signatureInput);
-            $this->assertStringContainsString('alg="eddsa"', $signatureInput);
+            $this->assertStringContainsString('alg="ed25519"', $signatureInput);
             $this->assertStringContainsString('tag="web-bot-auth"', $signatureInput);
             $this->assertStringContainsString('created=', $signatureInput);
             $this->assertStringContainsString('expires=', $signatureInput);


### PR DESCRIPTION
HTTP Message signature registry with IANA only defines ed25519 https://www.iana.org/assignments/http-message-signature/http-message-signature.xhtml#signature-algorithms

Similarily, JWK EdDSA algorithm is deprecated. Use Ed25519 instead. https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms

Note: I have note tested this PR. Only `s/eddsa/ed25519/g`